### PR TITLE
Fix esp32s3-core3, add ESP32-S3-N16R8, and more info

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,7 @@ framework = arduino
 monitor_speed = 115200
 
 [env:esp32s3-core3]
-platform = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF5_org
+platform = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53
 board = esp32-s3-devkitc-1
 board_build.flash_mode = qio
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,3 +50,12 @@ board_build.flash_mode = qio
 framework = arduino
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
+
+[env:esp32s3-N16R8]
+platform = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53
+board = 4d_systems_esp32s3_gen4_r8n16
+board_build.flash_mode = qio
+framework = arduino
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+build_flags = -D ARDUINO_USB_CDC_ON_BOOT=0

--- a/src/Chip_info.ino
+++ b/src/Chip_info.ino
@@ -337,6 +337,8 @@ void setup() {
 
     Serial.print("ESP32 SDK: "); Serial.println(ESP.getSdkVersion());
     Serial.print("ESP32 DEVICE: "); Serial.println(GetDeviceHardwareRevision());
+    Serial.print("ESP32 CHIP ID: "); Serial.println((uint32_t)ESP.getEfuseMac(), HEX);
+    Serial.print("ESP32 CPU CORES: "); Serial.println(ESP.getChipCores());
     Serial.print("ESP32 CPU FREQ: "); Serial.print(getCpuFrequencyMhz()); Serial.println(" MHz");
     Serial.print("ESP32 XTAL FREQ: "); Serial.print(getXtalFrequencyMhz()); Serial.println(" MHz");
     Serial.print("ESP32 APB FREQ: "); Serial.print(getApbFrequency() / 1000000.0, 1); Serial.println(" MHz");
@@ -350,6 +352,17 @@ void setup() {
     Serial.print("ESP32 FREE RAM: "); Serial.print(ESP.getFreeHeap() / 1024.0, 2); Serial.println(" KB");
     Serial.print("ESP32 MAX RAM ALLOC: "); Serial.print(ESP.getMaxAllocHeap() / 1024.0, 2); Serial.println(" KB");
     Serial.print("ESP32 FREE PSRAM: "); Serial.print(ESP.getFreePsram() / 1024.0, 2); Serial.println(" KB");
+    Serial.print("ESP32 TOTAL PSRAM: "); Serial.print(ESP.getPsramSize() / 1024.0, 2); Serial.println(" KB");
+
+    // Print MAC address
+    uint8_t mac[6];
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    Serial.print("ESP32 MAC: ");
+    for (int i = 0; i < 6; i++) {
+      if (i > 0) Serial.print(":");
+      Serial.print(mac[i], HEX);
+    }
+    Serial.println();
 }
 
 void loop() {


### PR DESCRIPTION
1. I've fixed the `env:esp32s3-core3` platform param to pull from the correct location.
2. Added a new build environment for the ESP32-S3-N16R8 which uses the `4d_systems_esp32s3_gen4_r8n16` board, which worked for my [knockoff ESP32-S3-Dev-Kit-C-1](https://www.aliexpress.us/item/3256808564662702.html).
3. Added output for ESP32 chip ID, CPU cores, total PSRAM, and MAC address in the serial output of `setup()`.

Example output now:
```
ESP32 SDK: 5.3.4.250826
ESP32 DEVICE: ESP32-S3 rev.2
ESP32 CHIP ID: F1234567
ESP32 CPU CORES: 2
ESP32 CPU FREQ: 240 MHz
ESP32 XTAL FREQ: 40 MHz
ESP32 APB FREQ: 80.0 MHz
ESP32 FLASH CHIP ID: 1234567
ESP32 FLASH CHIP FREQ: 80.0 MHz
ESP32 FLASH REAL SIZE: 16.00 MB
ESP32 FLASH REAL MODE: QIO
ESP32 FLASH MODE (MAGIC BYTE): 0, 0=QIO, 1=QOUT, 2=DIO, 3=DOUT
ESP32 RAM SIZE: 409.14 KB
ESP32 FREE RAM: 380.93 KB
ESP32 MAX RAM ALLOC: 312.00 KB
ESP32 FREE PSRAM: 6945.53 KB
ESP32 TOTAL PSRAM: 8000.00 KB
ESP32 MAC: A0:00:00:00:00:01
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the ESP32‑S3 N16R8 variant.
  - Startup diagnostics now print chip ID, CPU core count, total PSRAM, and Wi‑Fi MAC address for easier device identification.
- Chores
  - Updated ESP32‑S3 platform to target IDF53 for improved compatibility.
  - Preserved serial monitor exception decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->